### PR TITLE
Fix in mem limit 50

### DIFF
--- a/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/assetindex/InMemoryAssetIndex.java
+++ b/core/defaults/src/main/java/org/eclipse/dataspaceconnector/core/defaults/assetindex/InMemoryAssetIndex.java
@@ -96,7 +96,8 @@ public class InMemoryAssetIndex implements AssetIndex, DataAddressResolver, Asse
             }
 
             // ... then limit
-            return result.skip(querySpec.getOffset()).limit(querySpec.getLimit());
+            //return result.skip(querySpec.getOffset()).limit(querySpec.getLimit());
+            return result;
         } finally {
             lock.readLock().unlock();
         }

--- a/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
+++ b/extensions/sql/contract-definition-store-sql/src/main/java/org/eclipse/dataspaceconnector/sql/contractdefinition/store/SqlContractDefinitionStore.java
@@ -68,7 +68,7 @@ public class SqlContractDefinitionStore implements ContractDefinitionStore {
 
     @Override
     public @NotNull Collection<ContractDefinition> findAll() {
-        return findAll(QuerySpec.none()).collect(Collectors.toList());
+        return findAll(QuerySpec.Builder.newInstance().offset(0).limit(Integer.MAX_VALUE).build()).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
Workaround to allow more than 50 assets with in-memory storage.
Disables paging functionality. Needs a proper fix in the future.